### PR TITLE
Rename `readerwriter` to `readwriter`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: 'The name of the organization that owns the database'
     required: true
   role:
-    description: 'The role of the password. Allowed values are `reader`, `writer`, `readerwriter`, or `admin`. Defaults to `admin`.'
+    description: 'The role of the password. Allowed values are `reader`, `writer`, `readwriter`, or `admin`. Defaults to `admin`.'
     required: false
 outputs:
   username:


### PR DESCRIPTION
I believe the correct role name is `readwriter`, not `readerwriter`.

`readerwriter` gives me the following error:

```
{"error": "invalid role [readerwriter] requested"}
```

However, `readwriter` creates the password successfully.